### PR TITLE
chore(utils): formatDataAfterQuery removes unnecessary fields in rela…

### DIFF
--- a/packages/forms/src/Form.js
+++ b/packages/forms/src/Form.js
@@ -26,7 +26,19 @@ class Form extends React.Component<FormProps> {
   };
 
   collectProps = (): FinalFormProps => {
-    const { mutators, tableSchema, type, schema, onSubmit, initialValues, onSuccess, ignoreNonTableFields, permissions, ...restProps } = this.props;
+    const {
+      mutators,
+      tableSchema,
+      type,
+      schema,
+      onSubmit,
+      initialValues,
+      onSuccess,
+      ignoreNonTableFields,
+      permissions,
+      formatRelationToIds,
+      ...restProps
+    } = this.props;
 
     const collectedProps = {
       mutators: R.merge(arrayMutators, mutators),
@@ -37,7 +49,7 @@ class Form extends React.Component<FormProps> {
     };
 
     if (tableSchema && schema && type === MUTATION_TYPE.UPDATE && collectedProps.initialValues) {
-      collectedProps.initialValues = formatDataAfterQuery(tableSchema.name, collectedProps.initialValues, schema);
+      collectedProps.initialValues = formatDataAfterQuery(tableSchema.name, collectedProps.initialValues, schema, { formatRelationToIds });
     }
 
     const skipData = (value, fieldSchema) =>

--- a/packages/forms/src/types.js
+++ b/packages/forms/src/types.js
@@ -44,6 +44,7 @@ type FormProps = {
   schema?: Schema,
   type?: 'CREATE' | 'UPDATE',
   ignoreNonTableFields?: boolean,
+  formatRelationToIds?: boolean,
   permissions?: Object,
   onSuccess: (result: any, form: FormApi) => void,
 } & FinalFormProps;

--- a/packages/utils/src/formatters/formatDataAfterQuery.js
+++ b/packages/utils/src/formatters/formatDataAfterQuery.js
@@ -9,15 +9,16 @@ import {
   isMetaField,
 } from '../verifiers';
 
-import type { FieldSchema, TableSchema, Schema } from '../types';
+import type { FieldSchema, TableSchema, Schema, FormatDataAfterQueryOptions } from '../types';
 
 /**
  * Remove unnecessary data after fetch entity data by query
  * @param {string} tableName - The name of the table from the 8base API.
  * @param {Object} data - The entity data for format.
  * @param {Schema} schema - The schema of the used tables from the 8base API.
+ * @param {FormatDataAfterQueryOptions} options
  */
-const formatDataAfterQuery = (tableName: string, data: Object, schema: Schema) => {
+const formatDataAfterQuery = (tableName: string, data: Object, schema: Schema, options: FormatDataAfterQueryOptions = {}) => {
   const tableSchema: ?TableSchema = getTableSchemaByName(tableName, schema);
 
   if (!tableSchema) {
@@ -40,16 +41,24 @@ const formatDataAfterQuery = (tableName: string, data: Object, schema: Schema) =
     }
 
     if (isRelationField(fieldSchema) && !isFileField(fieldSchema) && result[fieldName]) {
-      const relationTableSchema: ?TableSchema = getTableSchemaById(fieldSchema.relation.refTable.id, schema);
-
-      if (!relationTableSchema) {
-        throw new Error(`Relation table schema with ${fieldSchema.relation.refTable.id} id not found in schema.`);
-      }
-
-      if (isListField(fieldSchema)) {
-        result[fieldName] = result[fieldName].map(item => formatDataAfterQuery(relationTableSchema.name, item, schema));
+      if (options.formatRelationToIds) {
+        if (isListField(fieldSchema)) {
+          result = R.assoc(fieldName, result[fieldName].map && result[fieldName].map(({ id }) => id), result);
+        } else {
+          result = R.assoc(fieldName, result[fieldName].id, result);
+        }
       } else {
-        result[fieldName] = formatDataAfterQuery(relationTableSchema.name, result[fieldName], schema);
+        const relationTableSchema: ?TableSchema = getTableSchemaById(fieldSchema.relation.refTable.id, schema);
+
+        if (!relationTableSchema) {
+          throw new Error(`Relation table schema with ${fieldSchema.relation.refTable.id} id not found in schema.`);
+        }
+
+        if (isListField(fieldSchema)) {
+          result[fieldName] = result[fieldName].map(item => formatDataAfterQuery(relationTableSchema.name, item, schema));
+        } else {
+          result[fieldName] = formatDataAfterQuery(relationTableSchema.name, result[fieldName], schema);
+        }
       }
     }
 

--- a/packages/utils/src/formatters/formatDataAfterQuery.js
+++ b/packages/utils/src/formatters/formatDataAfterQuery.js
@@ -42,6 +42,10 @@ const formatDataAfterQuery = (tableName: string, data: Object, schema: Schema) =
     if (isRelationField(fieldSchema) && !isFileField(fieldSchema) && result[fieldName]) {
       const relationTableSchema: ?TableSchema = getTableSchemaById(fieldSchema.relation.refTable.id, schema);
 
+      if (!relationTableSchema) {
+        throw new Error(`Relation table schema with ${fieldSchema.relation.refTable.id} id not found in schema.`);
+      }
+
       if (isListField(fieldSchema)) {
         result[fieldName] = result[fieldName].map(item => formatDataAfterQuery(relationTableSchema.name, item, schema));
       } else {

--- a/packages/utils/src/formatters/formatDataAfterQuery.js
+++ b/packages/utils/src/formatters/formatDataAfterQuery.js
@@ -1,7 +1,7 @@
 //@flow
 import * as R from 'ramda';
 
-import { getFieldSchemaByName, getTableSchemaByName } from '../selectors';
+import { getFieldSchemaByName, getTableSchemaByName, getTableSchemaById } from '../selectors';
 import {
   isRelationField,
   isFileField,
@@ -40,10 +40,12 @@ const formatDataAfterQuery = (tableName: string, data: Object, schema: Schema) =
     }
 
     if (isRelationField(fieldSchema) && !isFileField(fieldSchema) && result[fieldName]) {
+      const relationTableSchema: ?TableSchema = getTableSchemaById(fieldSchema.relation.refTable.id, schema);
+
       if (isListField(fieldSchema)) {
-        result = R.assoc(fieldName, result[fieldName].map && result[fieldName].map(({ id }) => id), result);
+        result[fieldName] = result[fieldName].map(item => formatDataAfterQuery(relationTableSchema.name, item, schema));
       } else {
-        result = R.assoc(fieldName, result[fieldName].id, result);
+        result[fieldName] = formatDataAfterQuery(relationTableSchema.name, result[fieldName], schema);
       }
     }
 

--- a/packages/utils/src/types.js
+++ b/packages/utils/src/types.js
@@ -95,3 +95,7 @@ export type QueryGeneratorConfig = {
   relationItemsCount?: number,
   includeColumns?: null | string[],
 };
+
+export type FormatDataAfterQueryOptions = {
+  formatRelationToIds?: boolean,
+};

--- a/packages/utils/test/__fixtures__/index.js
+++ b/packages/utils/test/__fixtures__/index.js
@@ -920,6 +920,17 @@ export const SCHEMA = [{
   isSystem: false,
   fields: [
     {
+      id: '5cc0849dfe73ad48a46103b0',
+      isSystem: true,
+      name: 'id',
+      displayName: 'ID',
+      fieldType: 'ID',
+      isRequired: true,
+      isUnique: true,
+      defaultValue: null,
+      relation: null,
+    },
+    {
       name: 'scalar',
       displayName: 'Scalar',
       description: null,
@@ -1040,6 +1051,17 @@ export const SCHEMA = [{
   displayName: 'Other Relation Table Schema',
   isSystem: false,
   fields: [
+    {
+      id: '5cc0849dfe73ad48a46103b0',
+      isSystem: true,
+      name: 'id',
+      displayName: 'ID',
+      fieldType: 'ID',
+      isRequired: true,
+      isUnique: true,
+      defaultValue: null,
+      relation: null,
+    },
     {
       name: 'scalar',
       displayName: 'Scalar',

--- a/packages/utils/test/__tests__/__snapshots__/formatDataAfterQuery.test.js.snap
+++ b/packages/utils/test/__tests__/__snapshots__/formatDataAfterQuery.test.js.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`As developer, I can format for create mutation, Compelex data with formatRelationToIds option. 1`] = `
+Object {
+  "address": Object {
+    "city": "Kenia Urhahn",
+    "state": "Scottie Swailes",
+    "street1": "Pamelia Quall",
+    "street2": "Lasonya Friedly",
+    "zip": "Timothy Ingleton",
+  },
+  "fileList": Array [
+    Object {
+      "downloadUrl": "https://cdn.filestackcontent.com/security=p:eyJjYWxsIjpbInJlYWQiXSwiZXhwaXJ5IjoxNTQwNDU5ODAxODYzLCJoYW5kbGUiOiI5U05UelRmVEFXTUZhckhyb2hBNiJ9,s:d019cfe489a72037a9fd57bfc008664b1ec5bd7d4e24f0979aa067d29d54c305/9SNTzTfTAWMFarHrohA6",
+      "fileId": "9SNTzTfTAWMFarHrohA6",
+      "filename": "9217163.png",
+      "id": "cjnodqoni000501qnkcga0qra",
+      "shareUrl": "https://prestaging-api.8basedev.com/file/download/cjnod10tj000001pjf7an05k2_Master/cjnodqoni000501qnkcga0qra",
+    },
+    Object {
+      "downloadUrl": "https://cdn.filestackcontent.com/security=p:eyJjYWxsIjpbInJlYWQiXSwiZXhwaXJ5IjoxNTQwNDU5ODAxODYzLCJoYW5kbGUiOiI1QVhRRjVTYVFSbWdyeFRKQ01xUSJ9,s:1ee9fe13f9a855acd1aad3330a7612b4c6849a7de4f9d45d5b831e596ca26115/5AXQF5SaQRmgrxTJCMqQ",
+      "fileId": "5AXQF5SaQRmgrxTJCMqQ",
+      "filename": "9217163.png",
+      "id": "cjnodqop0000601qnytfd866c",
+      "shareUrl": "https://prestaging-api.8basedev.com/file/download/cjnod10tj000001pjf7an05k2_Master/cjnodqop0000601qnytfd866c",
+    },
+  ],
+  "json": Object {
+    "somePropArray": Array [
+      "someValue1",
+      "someValue2",
+      "someValue3",
+    ],
+  },
+  "jsonList": Array [
+    Object {
+      "someProp": "someValue",
+    },
+    Object {
+      "somePropArray": Array [
+        "someValue1",
+        "someValue2",
+      ],
+    },
+  ],
+  "relation": null,
+  "relationList": Array [
+    "id-1",
+    "id-2",
+  ],
+  "scalar": "Scalar Value",
+  "scalarList": Array [
+    "Scalar List Value",
+  ],
+}
+`;
+
 exports[`As developer, I can format for create mutation, Compelex data. 1`] = `
 Object {
   "address": Object {

--- a/packages/utils/test/__tests__/__snapshots__/formatDataAfterQuery.test.js.snap
+++ b/packages/utils/test/__tests__/__snapshots__/formatDataAfterQuery.test.js.snap
@@ -45,7 +45,24 @@ Object {
   ],
   "relation": null,
   "relationList": Array [
-    "id",
+    Object {
+      "id": "id-1",
+      "nestedRelation": Object {
+        "id": "nestedId",
+        "scalar": "Nested Scalar Value",
+      },
+      "scalar": "Relation List Scalar Value",
+      "scalarList": Array [
+        "Relation List Scalar List Value",
+      ],
+    },
+    Object {
+      "id": "id-2",
+      "scalar": "Relation List Scalar Value",
+      "scalarList": Array [
+        "Relation List Scalar List Value",
+      ],
+    },
   ],
   "scalar": "Scalar Value",
   "scalarList": Array [

--- a/packages/utils/test/__tests__/formatDataAfterQuery.test.js
+++ b/packages/utils/test/__tests__/formatDataAfterQuery.test.js
@@ -74,4 +74,75 @@ describe('As developer, I can format for create mutation,', () => {
 
     expect(formatDataAfterQuery('tableSchema', data, SCHEMA)).toMatchSnapshot();
   });
+
+  it('Compelex data with formatRelationToIds option.', () => {
+    const data = {
+      meta: 'meta',
+      address: {
+        street1: 'Pamelia Quall',
+        street2: 'Lasonya Friedly',
+        zip: 'Timothy Ingleton',
+        city: 'Kenia Urhahn',
+        state: 'Scottie Swailes',
+      },
+      scalar: 'Scalar Value',
+      scalarList: [
+        'Scalar List Value',
+      ],
+      relation: null,
+      relationList: {
+        items: [{
+          id: 'id-1',
+          scalar: 'Relation List Scalar Value',
+          scalarList: [
+            'Relation List Scalar List Value',
+          ],
+          nestedRelation: {
+            id: 'nestedId',
+            scalar: 'Nested Scalar Value',
+            nonNestedRelationField: 'should be removed',
+          },
+        }, {
+          id: 'id-2',
+          scalar: 'Relation List Scalar Value',
+          scalarList: [
+            'Relation List Scalar List Value',
+          ],
+        }],
+      },
+      fileList: {
+        items: [{
+          id: 'cjnodqoni000501qnkcga0qra',
+          fileId: '9SNTzTfTAWMFarHrohA6',
+          filename: '9217163.png',
+          downloadUrl: 'https://cdn.filestackcontent.com/security=p:eyJjYWxsIjpbInJlYWQiXSwiZXhwaXJ5IjoxNTQwNDU5ODAxODYzLCJoYW5kbGUiOiI5U05UelRmVEFXTUZhckhyb2hBNiJ9,s:d019cfe489a72037a9fd57bfc008664b1ec5bd7d4e24f0979aa067d29d54c305/9SNTzTfTAWMFarHrohA6',
+          shareUrl: 'https://prestaging-api.8basedev.com/file/download/cjnod10tj000001pjf7an05k2_Master/cjnodqoni000501qnkcga0qra',
+        }, {
+          id: 'cjnodqop0000601qnytfd866c',
+          fileId: '5AXQF5SaQRmgrxTJCMqQ',
+          filename: '9217163.png',
+          downloadUrl: 'https://cdn.filestackcontent.com/security=p:eyJjYWxsIjpbInJlYWQiXSwiZXhwaXJ5IjoxNTQwNDU5ODAxODYzLCJoYW5kbGUiOiI1QVhRRjVTYVFSbWdyeFRKQ01xUSJ9,s:1ee9fe13f9a855acd1aad3330a7612b4c6849a7de4f9d45d5b831e596ca26115/5AXQF5SaQRmgrxTJCMqQ',
+          shareUrl: 'https://prestaging-api.8basedev.com/file/download/cjnod10tj000001pjf7an05k2_Master/cjnodqop0000601qnytfd866c',
+        }],
+      },
+      json: {
+        somePropArray: [
+          'someValue1',
+          'someValue2',
+          'someValue3',
+        ],
+      },
+      jsonList: [
+        { someProp: 'someValue' },
+        {
+          somePropArray: [
+            'someValue1',
+            'someValue2',
+          ],
+        },
+      ],
+    };
+
+    expect(formatDataAfterQuery('tableSchema', data, SCHEMA, { formatRelationToIds: true })).toMatchSnapshot();
+  });
 });

--- a/packages/utils/test/__tests__/formatDataAfterQuery.test.js
+++ b/packages/utils/test/__tests__/formatDataAfterQuery.test.js
@@ -21,12 +21,22 @@ describe('As developer, I can format for create mutation,', () => {
       relation: null,
       relationList: {
         items: [{
-          id: 'id',
+          id: 'id-1',
           scalar: 'Relation List Scalar Value',
           scalarList: [
             'Relation List Scalar List Value',
           ],
-          nestedRelation: '5b32159b66a450c047285628',
+          nestedRelation: {
+            id: 'nestedId',
+            scalar: 'Nested Scalar Value',
+            nonNestedRelationField: 'should be removed',
+          },
+        }, {
+          id: 'id-2',
+          scalar: 'Relation List Scalar Value',
+          scalarList: [
+            'Relation List Scalar List Value',
+          ],
         }],
       },
       fileList: {


### PR DESCRIPTION
…tions

Now `formatDataAfterQuery` doesn't save only ids of relations but read table schema of the relation and removes unnecessary fields