### PR TITLE
feat(app-provider): add possibility to pass static introspection query result

### DIFF
--- a/packages/app-provider/src/AppProvider.tsx
+++ b/packages/app-provider/src/AppProvider.tsx
@@ -18,6 +18,7 @@ type AppProviderProps = ApolloContainerPassedProps & {
  * @prop {Function} [onRequestError] - The callback which called when request is fail.
  * @prop {Function} [extendLinks] - Function to extend standart array of the links.
  * @prop {Function} [children] - The render function.
+ * @prop {Object} [introspectionQueryResultData] - The fragment type for introspection fragments matcher.
  */
 const AppProvider = ({
   uri,
@@ -28,6 +29,7 @@ const AppProvider = ({
   children,
   autoSignUp,
   authProfileId,
+  introspectionQueryResultData,
 }: AppProviderProps): any =>
   !!authClient ? (
     <AuthProvider authClient={authClient}>
@@ -39,6 +41,7 @@ const AppProvider = ({
         onRequestError={onRequestError}
         autoSignUp={autoSignUp}
         authProfileId={authProfileId}
+        introspectionQueryResultData={introspectionQueryResultData}
       >
         <TableSchemaProvider>{children}</TableSchemaProvider>
       </ApolloContainer>
@@ -50,6 +53,7 @@ const AppProvider = ({
       extendLinks={extendLinks}
       onRequestSuccess={onRequestSuccess}
       onRequestError={onRequestError}
+      introspectionQueryResultData={introspectionQueryResultData}
     >
       <TableSchemaProvider>{children}</TableSchemaProvider>
     </ApolloContainer>

--- a/packages/app-provider/src/FragmentsSchemaContainer.ts
+++ b/packages/app-provider/src/FragmentsSchemaContainer.ts
@@ -5,13 +5,13 @@ type FragmentsSchemaContainerProps = {
   uri: string;
   children: (args: {
     loading: boolean;
-    fragmentsSchema: object | null;
+    introspectionQueryResultData: object | null;
   }) => React.ReactNode;
 };
 
 type FragmentsSchemaContainerState = {
   loading: boolean;
-  fragmentsSchema: null | Object;
+  introspectionQueryResultData: null | Object;
 };
 
 class FragmentsSchemaContainer extends React.PureComponent<
@@ -19,7 +19,7 @@ class FragmentsSchemaContainer extends React.PureComponent<
   FragmentsSchemaContainerState
 > {
   public state: FragmentsSchemaContainerState = {
-    fragmentsSchema: null,
+    introspectionQueryResultData: null,
     loading: true,
   };
 
@@ -28,16 +28,16 @@ class FragmentsSchemaContainer extends React.PureComponent<
 
     this.setState({ loading: true });
 
-    const fragmentsSchema = await fetchFragmentsSchema(uri);
+    const introspectionQueryResultData = await fetchFragmentsSchema(uri);
 
-    this.setState({ loading: false, fragmentsSchema });
+    this.setState({ loading: false, introspectionQueryResultData });
   }
 
   public render() {
-    const { loading, fragmentsSchema } = this.state;
+    const { loading, introspectionQueryResultData } = this.state;
     const { children } = this.props;
 
-    return children({ loading, fragmentsSchema });
+    return children({ loading, introspectionQueryResultData });
   }
 }
 

--- a/packages/app-provider/src/types.ts
+++ b/packages/app-provider/src/types.ts
@@ -11,4 +11,5 @@ export type ApolloContainerPassedProps = {
     links: ApolloLink[],
     options: { getAuthState?: () => Promise<AuthState> },
   ) => ApolloLink[];
+  introspectionQueryResultData?: Object;
 };


### PR DESCRIPTION
If u don't have dynamic GraphQL schema u could use static `introspectionQueryResultData` for speed up app first loading.

https://www.apollographql.com/docs/react/advanced/fragments/#fragments-on-unions-and-interfaces

```js
import React from 'react';
import { AppProvider } from '@8base/app-provider';
import { WebAuth0AuthClient } from '@8base/web-auth0-auth-client';

import introspectionQueryResultData from './introspectionQueryResultData.json';

const { REACT_APP_8BASE_API_URL } = process.env;

const authClient = new WebAuth0AuthClient({
  domain: AUTH_DOMAIN,
  clientId: AUTH_CLIENT_ID,
  redirectUri: `${window.location.origin}/auth/callback`,
  logoutRedirectUri: `${window.location.origin}/auth`,
  workspaceId: 'workspace-id',
});

const Application = () => {
  const renderContent = ({ loading }) => loading ? 'Loading...' : 'Content';

  return (
    <AppProvider
      uri={ REACT_APP_8BASE_API_URL }
      authClient={ authClient }
      introspectionQueryResultData={ introspectionQueryResultData }
    >
      {renderContent}
    </AppProvider>
  );
};

export { Application };
```

or u can pass `null` if u don't want use fragments and unions in ur app

```js
import React from 'react';
import { AppProvider } from '@8base/app-provider';
import { WebAuth0AuthClient } from '@8base/web-auth0-auth-client';

const { REACT_APP_8BASE_API_URL } = process.env;

const authClient = new WebAuth0AuthClient({
  domain: AUTH_DOMAIN,
  clientId: AUTH_CLIENT_ID,
  redirectUri: `${window.location.origin}/auth/callback`,
  logoutRedirectUri: `${window.location.origin}/auth`,
  workspaceId: 'workspace-id',
});

const Application = () => {
  const renderContent = ({ loading }) => loading ? 'Loading...' : 'Content';

  return (
    <AppProvider
      uri={ REACT_APP_8BASE_API_URL }
      authClient={ authClient }
      introspectionQueryResultData={ null }
    >
      {renderContent}
    </AppProvider>
  );
};

export { Application };
```