### PR TITLE
feat(client): formatDataMutation should be able to update relations

### DIFF
--- a/packages/utils/src/constants/schemaConstants.ts
+++ b/packages/utils/src/constants/schemaConstants.ts
@@ -166,7 +166,7 @@ export const SYSTEM_TABLES: {
   USERS: 'Users',
 };
 
-export const MUTATION_FILE_FIELDS = ['fileId', 'public', 'filename', 'meta', 'mods'];
+export const MUTATION_FILE_FIELDS = ['id', 'fileId', 'public', 'filename', 'meta', 'mods'];
 
 export const APP_STATUS: {
   ACTIVE: 'ACTIVE';
@@ -190,4 +190,8 @@ export const TABLE_ORIGIN_TYPES = {
   LOCAL: 'LOCAL',
   VIEW: 'VIEW',
   REMOTE: 'REMOTE',
+};
+
+export const UPDATE_META_FIELDS_TO_PRESERVE: { [key: string]: boolean | void } = {
+  id: true,
 };

--- a/packages/utils/src/formatters/formatDataAfterQuery.ts
+++ b/packages/utils/src/formatters/formatDataAfterQuery.ts
@@ -2,9 +2,9 @@ import * as R from 'ramda';
 
 import { tableSelectors, tablesListSelectors } from '../selectors';
 import { isRelationField, isFileField, isListField, isMetaField } from '../verifiers';
-
-import { TableSchema, Schema, FormatDataAfterQueryOptions } from '../types';
+import { Schema, FormatDataAfterQueryOptions } from '../types';
 import { SDKError, ERROR_CODES, PACKAGES } from '../errors';
+import { UPDATE_META_FIELDS_TO_PRESERVE } from '../constants';
 
 interface IFormatDataAfterQueryMeta {
   tableName: string;
@@ -46,7 +46,7 @@ const formatDataAfterQuery = (
         if (data[fieldName]) {
           result[fieldName] = data[fieldName].items;
         }
-      } else if (!isMetaField(fieldSchema)) {
+      } else if (!isMetaField(fieldSchema) || UPDATE_META_FIELDS_TO_PRESERVE[fieldName]) {
         result = R.assoc(fieldName, data[fieldName], result);
       }
 

--- a/packages/utils/src/formatters/formatDataForMutation.ts
+++ b/packages/utils/src/formatters/formatDataForMutation.ts
@@ -1,37 +1,41 @@
 import * as R from 'ramda';
 
-import { MUTATION_TYPE, MUTATION_FILE_FIELDS } from '../constants';
+import { MUTATION_TYPE, MUTATION_FILE_FIELDS, UPDATE_META_FIELDS_TO_PRESERVE } from '../constants';
 import { tableSelectors, tablesListSelectors } from '../selectors';
 import { isMetaField, isFileField, isRelationField, isListField, isFilesTable } from '../verifiers';
 import { formatFieldDataForMutation } from './formatFieldDataForMutation';
 import { omitDeep } from './omitDeep';
 import { SDKError, ERROR_CODES, PACKAGES } from '../errors';
-import { MutationType, FieldSchema, TableSchema, Schema } from '../types';
-
-interface IOptions {
-  skip?: boolean | ((...args: any[]) => boolean);
-  mutate?: (...args: any[]) => any;
-  ignoreNonTableFields?: boolean;
-}
+import { MutationType, Schema, FormatDataForMutationOptions } from '../types';
 
 interface IFormatDataForMutationMeta {
   tableName: string;
-  appName?: string;
   schema: Schema;
+  appName?: string;
+  initialData?: any;
 }
+
+const DEFAULT_OPTIONS: Partial<FormatDataForMutationOptions> = {
+  ignoreNonTableFields: true,
+};
+
+const shouldPreserveMetaField = ({ type, fieldName }: { type: MutationType; fieldName: string }) => {
+  return type !== MUTATION_TYPE.UPDATE ? false : UPDATE_META_FIELDS_TO_PRESERVE[fieldName];
+};
 
 /**
  * Formats entity data for create or update mutation based on passed schema.
  * @param {MutationType} type - The type of the mutation.
  * @param {string} tableName - The name of the table from the 8base API.
  * @param {Object} data - The entity data for format.
+ * @param {Object} initialData - Initial data. Used in UPDATE on submit formatting to disconnect removed relations.
  * @param {Schema} schema - The schema of the used tables from the 8base API.
  */
 const formatDataForMutation = (
   type: MutationType,
   data: any,
-  { tableName, appName, schema }: IFormatDataForMutationMeta,
-  options: IOptions = {},
+  { tableName, appName, schema, initialData }: IFormatDataForMutationMeta,
+  options: FormatDataForMutationOptions = {},
 ) => {
   if (R.not(type in MUTATION_TYPE)) {
     throw new SDKError(ERROR_CODES.INVALID_ARGUMENT, PACKAGES.UTILS, `Invalid mutation type: ${type}`);
@@ -51,6 +55,8 @@ const formatDataForMutation = (
     );
   }
 
+  options = R.mergeDeepRight(DEFAULT_OPTIONS, options);
+
   const formatedData = R.reduce(
     (result: { [key: string]: any }, fieldName: string) => {
       if (
@@ -62,7 +68,7 @@ const formatDataForMutation = (
       }
 
       const fieldSchema = tableSelectors.getFieldByName(tableSchema, fieldName);
-      const { skip, mutate, ignoreNonTableFields = true } = options;
+      const { skip, mutate, ignoreNonTableFields } = options;
 
       if (!fieldSchema) {
         if (ignoreNonTableFields) {
@@ -76,11 +82,12 @@ const formatDataForMutation = (
         return result;
       }
 
-      if (isMetaField(fieldSchema)) {
+      if (isMetaField(fieldSchema) && !shouldPreserveMetaField({ type, fieldName })) {
         return result;
       }
 
       let formatedFieldData = data[fieldName];
+      const initialFieldData = R.path([fieldName], initialData);
 
       if ((isFileField(fieldSchema) || isRelationField(fieldSchema)) && isListField(fieldSchema)) {
         if (R.isNil(formatedFieldData)) {
@@ -93,7 +100,16 @@ const formatDataForMutation = (
         }
       }
 
-      formatedFieldData = formatFieldDataForMutation(type, formatedFieldData, { fieldSchema, schema });
+      formatedFieldData = formatFieldDataForMutation(
+        type,
+        formatedFieldData,
+        {
+          fieldSchema,
+          schema,
+          initialData: initialFieldData,
+        },
+        options,
+      );
 
       if (typeof mutate === 'function') {
         formatedFieldData = mutate(formatedFieldData, data[fieldName], fieldSchema);

--- a/packages/utils/src/formatters/formatFieldData.ts
+++ b/packages/utils/src/formatters/formatFieldData.ts
@@ -1,16 +1,23 @@
+import { MutationType, FieldSchema, Schema, FormatDataForMutationOptions } from '../types';
 import { formatFieldDataListItem } from './formatFieldDataListItem';
-
-import { MutationType, FieldSchema, Schema } from '../types';
 
 interface IFormatFieldDataMeta {
   fieldSchema: FieldSchema;
   schema: Schema;
+  initialData?: any;
 }
 
-export const formatFieldData = (type: MutationType, data: any, { fieldSchema, schema }: IFormatFieldDataMeta) => {
-  const nextData = formatFieldDataListItem(type, data, { fieldSchema, schema });
+export const formatFieldData = (
+  type: MutationType,
+  data: any,
+  { fieldSchema, schema, initialData }: IFormatFieldDataMeta,
+  options?: FormatDataForMutationOptions,
+) => {
+  const nextData = formatFieldDataListItem(type, data, { fieldSchema, schema, initialData }, options);
 
-  return {
-    [nextData.type]: nextData.data,
-  };
+  return nextData
+    ? {
+        [nextData.type]: nextData.data,
+      }
+    : null;
 };

--- a/packages/utils/src/formatters/formatFieldDataForMutation.ts
+++ b/packages/utils/src/formatters/formatFieldDataForMutation.ts
@@ -1,10 +1,9 @@
 import * as R from 'ramda';
 
 import * as verifiers from '../verifiers';
+import { MutationType, FieldSchema, Schema, FormatDataForMutationOptions } from '../types';
 import { formatFieldDataList } from './formatFieldDataList';
 import { formatFieldData } from './formatFieldData';
-
-import { MutationType, FieldSchema, Schema } from '../types';
 
 const formatJSON = (data: any) => {
   if (typeof data === 'string' && data.length === 0) {
@@ -17,20 +16,22 @@ const formatJSON = (data: any) => {
 interface IFormatFieldDataForMutationMeta {
   fieldSchema: FieldSchema;
   schema: Schema;
+  initialData?: any;
 }
 
 const formatFieldDataForMutation = (
   type: MutationType,
   data: any,
-  { fieldSchema, schema }: IFormatFieldDataForMutationMeta,
+  { fieldSchema, schema, initialData }: IFormatFieldDataForMutationMeta,
+  options?: FormatDataForMutationOptions,
 ) => {
   let nextData = data;
 
   if (verifiers.isFileField(fieldSchema) || verifiers.isRelationField(fieldSchema)) {
     if (verifiers.isListField(fieldSchema)) {
-      nextData = formatFieldDataList(type, data, { fieldSchema, schema });
+      nextData = formatFieldDataList(type, data, { fieldSchema, schema, initialData }, options);
     } else {
-      nextData = formatFieldData(type, data, { fieldSchema, schema });
+      nextData = formatFieldData(type, data, { fieldSchema, schema, initialData }, options);
     }
   } else if (verifiers.isAddressField(fieldSchema)) {
     if (verifiers.isListField(fieldSchema)) {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -177,3 +177,9 @@ export type QueryGeneratorConfig = {
 export type FormatDataAfterQueryOptions = {
   formatRelationToIds?: boolean;
 };
+
+export type FormatDataForMutationOptions = {
+  skip?: boolean | ((...args: any[]) => boolean);
+  mutate?: (...args: any[]) => any;
+  ignoreNonTableFields?: boolean;
+};

--- a/packages/utils/test/__fixtures__/index.ts
+++ b/packages/utils/test/__fixtures__/index.ts
@@ -941,12 +941,13 @@ export const SCHEMA: any[] = [
     fields: [
       {
         id: '5cc0849dfe73ad48a46103b0',
-        isSystem: true,
         name: 'id',
         displayName: 'ID',
         fieldType: 'ID',
+        isSystem: true,
         isRequired: true,
         isUnique: true,
+        isMeta: true,
         defaultValue: null,
         relation: null,
       },

--- a/packages/utils/test/__tests__/__snapshots__/formatDataForMutation.test.ts.snap
+++ b/packages/utils/test/__tests__/__snapshots__/formatDataForMutation.test.ts.snap
@@ -55,9 +55,18 @@ Object {
         "filename": "Screenshot at авг. 13 15-22-49.png",
       },
     ],
-    "reconnect": Array [
+    "disconnect": Array [
       Object {
-        "id": "1234",
+        "id": "removed-file-1",
+      },
+    ],
+    "update": Array [
+      Object {
+        "data": Object {
+          "fileId": "file-id",
+          "filename": "Screenshot at авг. 13 15-22-49.png",
+          "id": "1234",
+        },
       },
     ],
   },
@@ -67,7 +76,7 @@ Object {
     2,
   ],
   "relation": Object {
-    "create": Object {
+    "update": Object {
       "scalar": "Relation Scalar Value",
     },
   },
@@ -80,11 +89,16 @@ Object {
           },
         },
         "nestedRelationList": Object {
+          "connect": Array [
+            Object {
+              "id": "nested-relation-id",
+            },
+          ],
           "create": Array [
             Object {
-              "scalar": "Relation List Nested Relation List Scalar Value",
+              "scalar": "New Relation List Nested Relation List Scalar Value",
               "scalarList": Array [
-                "Relation List Nested Relation List Scalar List Value",
+                "New Relation List Nested Relation List Scalar List Value",
               ],
             },
           ],
@@ -95,7 +109,200 @@ Object {
         ],
       },
     ],
-    "reconnect": Array [],
+    "disconnect": Array [
+      Object {
+        "id": "removed-relation-list-1",
+      },
+    ],
+    "update": Array [
+      Object {
+        "data": Object {
+          "id": "connect-relation-list-1",
+        },
+      },
+      Object {
+        "data": Object {
+          "id": "relation-list-1",
+          "nestedRelation": Object {
+            "create": Object {
+              "scalar": "New Nested Relation Scalar Value",
+            },
+          },
+          "nestedRelationList": Object {
+            "create": Array [
+              Object {
+                "scalar": "Relation List Nested Relation List Scalar Value",
+                "scalarList": Array [
+                  "Relation List Nested Relation List Scalar List Value",
+                ],
+              },
+            ],
+          },
+          "scalar": "Update Relation List Scalar Value",
+          "scalarList": Array [
+            "Update Relation List Scalar List Value",
+          ],
+        },
+      },
+      Object {
+        "data": Object {
+          "id": "relation-list-2",
+          "nestedRelation": Object {
+            "update": Object {
+              "scalar": "Updated Nested Relation Scalar Value",
+            },
+          },
+          "nestedRelationList": Object {
+            "update": Array [
+              Object {
+                "data": Object {
+                  "id": "nested-relation-2-2",
+                  "scalar": "Relation List Nested Relation List Scalar Value",
+                  "scalarList": Array [
+                    "Relation List Nested Relation List Scalar List Value",
+                  ],
+                },
+              },
+            ],
+          },
+          "scalar": "Update Relation List Scalar Value",
+          "scalarList": Array [
+            "Update Relation List Scalar List Value",
+          ],
+        },
+      },
+    ],
+  },
+  "scalar": "Scalar Value",
+  "scalarList": Array [
+    "Scalar List Value",
+  ],
+}
+`;
+
+exports[`As developer, I can format for update mutation, Compelex data. 2`] = `
+Object {
+  "address": Object {
+    "city": "Kenia Urhahn",
+    "state": "Scottie Swailes",
+    "street1": "Pamelia Quall",
+    "street2": "Lasonya Friedly",
+    "zip": "Timothy Ingleton",
+  },
+  "fileList": Object {
+    "create": Array [
+      Object {
+        "fileId": "file-id",
+        "filename": "Screenshot at авг. 13 15-22-49.png",
+      },
+    ],
+    "update": Array [
+      Object {
+        "data": Object {
+          "fileId": "file-id",
+          "filename": "Screenshot at авг. 13 15-22-49.png",
+          "id": "1234",
+        },
+      },
+    ],
+  },
+  "number": 1,
+  "numberList": Array [
+    1,
+    2,
+  ],
+  "relation": Object {
+    "update": Object {
+      "scalar": "Relation Scalar Value",
+    },
+  },
+  "relationList": Object {
+    "create": Array [
+      Object {
+        "nestedRelation": Object {
+          "connect": Object {
+            "id": "5b32159b66a450c047285628",
+          },
+        },
+        "nestedRelationList": Object {
+          "connect": Array [
+            Object {
+              "id": "nested-relation-id",
+            },
+          ],
+          "create": Array [
+            Object {
+              "scalar": "New Relation List Nested Relation List Scalar Value",
+              "scalarList": Array [
+                "New Relation List Nested Relation List Scalar List Value",
+              ],
+            },
+          ],
+        },
+        "scalar": "Relation List Scalar Value",
+        "scalarList": Array [
+          "Relation List Scalar List Value",
+        ],
+      },
+    ],
+    "update": Array [
+      Object {
+        "data": Object {
+          "id": "connect-relation-list-1",
+        },
+      },
+      Object {
+        "data": Object {
+          "id": "relation-list-1",
+          "nestedRelation": Object {
+            "create": Object {
+              "scalar": "New Nested Relation Scalar Value",
+            },
+          },
+          "nestedRelationList": Object {
+            "create": Array [
+              Object {
+                "scalar": "Relation List Nested Relation List Scalar Value",
+                "scalarList": Array [
+                  "Relation List Nested Relation List Scalar List Value",
+                ],
+              },
+            ],
+          },
+          "scalar": "Update Relation List Scalar Value",
+          "scalarList": Array [
+            "Update Relation List Scalar List Value",
+          ],
+        },
+      },
+      Object {
+        "data": Object {
+          "id": "relation-list-2",
+          "nestedRelation": Object {
+            "update": Object {
+              "scalar": "Updated Nested Relation Scalar Value",
+            },
+          },
+          "nestedRelationList": Object {
+            "update": Array [
+              Object {
+                "data": Object {
+                  "id": "nested-relation-2-2",
+                  "scalar": "Relation List Nested Relation List Scalar Value",
+                  "scalarList": Array [
+                    "Relation List Nested Relation List Scalar List Value",
+                  ],
+                },
+              },
+            ],
+          },
+          "scalar": "Update Relation List Scalar Value",
+          "scalarList": Array [
+            "Update Relation List Scalar List Value",
+          ],
+        },
+      },
+    ],
   },
   "scalar": "Scalar Value",
   "scalarList": Array [

--- a/packages/utils/test/__tests__/formatDataForMutation.test.ts
+++ b/packages/utils/test/__tests__/formatDataForMutation.test.ts
@@ -1,3 +1,5 @@
+import * as R from 'ramda';
+
 import { formatDataForMutation, MUTATION_TYPE } from '../../src';
 import { SCHEMA } from '../__fixtures__';
 
@@ -69,9 +71,7 @@ describe('As developer, I can format for create mutation,', () => {
     };
 
     expect(formatDataForMutation(MUTATION_TYPE.CREATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
-      relation: {
-        connect: {},
-      },
+      relation: null,
     });
   });
 
@@ -81,9 +81,7 @@ describe('As developer, I can format for create mutation,', () => {
     };
 
     expect(formatDataForMutation(MUTATION_TYPE.CREATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
-      file: {
-        connect: {},
-      },
+      file: null,
     });
   });
 
@@ -401,7 +399,25 @@ describe('As developer, I can format for update mutation,', () => {
 
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
       relation: {
-        reconnect: { id: '5b32159b66a4500f96285626' },
+        connect: { id: '5b32159b66a4500f96285626' },
+      },
+    });
+  });
+
+  it('Data with removed relation reference.', () => {
+    const initialData = {
+      relation: '5b32159b66a4500f96285626',
+    };
+
+    const data = {
+      relation: undefined,
+    };
+
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA, initialData }),
+    ).toEqual({
+      relation: {
+        disconnect: { id: '5b32159b66a4500f96285626' },
       },
     });
   });
@@ -414,7 +430,24 @@ describe('As developer, I can format for update mutation,', () => {
       },
     };
 
+    const initialData = {
+      relation: {
+        id: 'removed-relation-1',
+      },
+    };
+
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
+      relation: {
+        create: {
+          scalar: 'Relation Scalar Value',
+          scalarList: ['Relation Scalar List Value'],
+        },
+      },
+    });
+
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA, initialData }),
+    ).toEqual({
       relation: {
         create: {
           scalar: 'Relation Scalar Value',
@@ -433,11 +466,27 @@ describe('As developer, I can format for update mutation,', () => {
       },
     };
 
+    const initialData = {
+      relation: {
+        id: 'removed-relation-1',
+        scalar: 'Relation Scalar Value',
+        scalarList: ['Relation Scalar List Value'],
+      },
+    };
+
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
       relation: {
-        reconnect: {
-          id: 'id',
-        },
+        update: R.dissoc('id', data.relation),
+      },
+    });
+
+    // TODO: For now, it will update despite ids are different in `data` and `initialData`.
+    // We probably should connect instead of update in that case.
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA, initialData }),
+    ).toEqual({
+      relation: {
+        update: R.dissoc('id', data.relation),
       },
     });
   });
@@ -448,9 +497,7 @@ describe('As developer, I can format for update mutation,', () => {
     };
 
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
-      relation: {
-        reconnect: {},
-      },
+      relation: null,
     });
   });
 
@@ -460,9 +507,7 @@ describe('As developer, I can format for update mutation,', () => {
     };
 
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
-      file: {
-        reconnect: {},
-      },
+      file: null,
     });
   });
 
@@ -492,6 +537,7 @@ describe('As developer, I can format for update mutation,', () => {
       id: '5b32159b66a4500f96285626',
       fileId: 'file-id',
       filename: 'Screenshot at авг. 13 15-22-49.png',
+      downloadUrl: 'downloadUrl',
     };
 
     const data = {
@@ -500,7 +546,7 @@ describe('As developer, I can format for update mutation,', () => {
 
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
       file: {
-        reconnect: { id: file.id },
+        update: R.omit(['id', 'downloadUrl'], file),
       },
     });
   });
@@ -512,7 +558,7 @@ describe('As developer, I can format for update mutation,', () => {
 
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
       file: {
-        reconnect: { id: '5b32159b66a4500f96285626' },
+        connect: { id: '5b32159b66a4500f96285626' },
       },
     });
   });
@@ -524,7 +570,7 @@ describe('As developer, I can format for update mutation,', () => {
 
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
       fileList: {
-        reconnect: [{ id: '5b32159b66a4500f96285626' }],
+        connect: [{ id: '5b32159b66a4500f96285626' }],
       },
     });
   });
@@ -536,7 +582,26 @@ describe('As developer, I can format for update mutation,', () => {
 
     expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
       relationList: {
-        reconnect: [{ id: '5b32159b66a450c047285628' }, { id: '5b32159b66a450fae928562a' }],
+        connect: [{ id: '5b32159b66a450c047285628' }, { id: '5b32159b66a450fae928562a' }],
+      },
+    });
+  });
+
+  it('Data with removed relation list reference.', () => {
+    const initialData = {
+      relationList: ['5b32159b66a450c047285628', '5b32159b66a450fae928562a'],
+    };
+
+    const data = {
+      relationList: ['5b32159b66a450c047285628'],
+    };
+
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA, initialData }),
+    ).toEqual({
+      relationList: {
+        connect: [{ id: '5b32159b66a450c047285628' }],
+        disconnect: [{ id: '5b32159b66a450fae928562a' }],
       },
     });
   });
@@ -559,8 +624,94 @@ describe('As developer, I can format for update mutation,', () => {
             scalarList: ['Relation List Scalar List Value'],
           },
         ],
-        reconnect: [],
       },
+    });
+  });
+
+  it('Data with new and existing relations.', () => {
+    const data = {
+      relationList: [
+        'inline-relation-01',
+        {
+          id: 'update-relation-01',
+          scalar: 'Update relation scalar value',
+          scalarList: ['Update relation scalar list value'],
+        },
+        {
+          scalar: 'New relation scalar value',
+          scalarList: ['New relation scalar list value'],
+        },
+        {
+          id: 'connect-relation-01',
+        },
+      ],
+    };
+
+    const initialData = {
+      relationList: [
+        {
+          id: 'update-relation-01',
+          scalar: 'Update relation scalar value',
+          scalarList: ['Update relation scalar list value'],
+        },
+        {
+          id: 'removed-relation-01',
+          scalar: 'Removed relation scalar value',
+          scalarList: ['Removed relation scalar list value'],
+        },
+      ],
+    };
+
+    const expectedRelationListWithoutDisconnect = {
+      connect: [
+        {
+          id: 'inline-relation-01',
+        },
+      ],
+      update: [
+        {
+          data: {
+            id: 'update-relation-01',
+            scalar: 'Update relation scalar value',
+            scalarList: ['Update relation scalar list value'],
+          },
+        },
+        // TODO: For now, it will update despite there no such id in `initialData`.
+        // We probably should connect instead of update in that case.
+        {
+          data: {
+            id: 'connect-relation-01',
+          },
+        },
+      ],
+      create: [
+        {
+          scalar: 'New relation scalar value',
+          scalarList: ['New relation scalar list value'],
+        },
+      ],
+    };
+
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, {
+        tableName: 'tableSchema',
+        schema: SCHEMA,
+        initialData,
+      }),
+    ).toEqual({
+      relationList: {
+        ...expectedRelationListWithoutDisconnect,
+        disconnect: [{ id: 'removed-relation-01' }],
+      },
+    });
+
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, {
+        tableName: 'tableSchema',
+        schema: SCHEMA,
+      }),
+    ).toEqual({
+      relationList: expectedRelationListWithoutDisconnect,
     });
   });
 
@@ -569,10 +720,13 @@ describe('As developer, I can format for update mutation,', () => {
       relationList: null,
     };
 
-    expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
-      relationList: {
-        reconnect: [],
-      },
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, {
+        tableName: 'tableSchema',
+        schema: SCHEMA,
+      }),
+    ).toEqual({
+      relationList: {},
     });
   });
 
@@ -581,10 +735,13 @@ describe('As developer, I can format for update mutation,', () => {
       relationList: [],
     };
 
-    expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
-      relationList: {
-        reconnect: [],
-      },
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, {
+        tableName: 'tableSchema',
+        schema: SCHEMA,
+      }),
+    ).toEqual({
+      relationList: {},
     });
   });
 
@@ -599,13 +756,16 @@ describe('As developer, I can format for update mutation,', () => {
       ],
     };
 
-    expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
+    const expectedUpdateData = data.relationList.map(item => ({ data: item }));
+
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, {
+        tableName: 'tableSchema',
+        schema: SCHEMA,
+      }),
+    ).toEqual({
       relationList: {
-        reconnect: [
-          {
-            id: data.relationList[0].id,
-          },
-        ],
+        update: expectedUpdateData,
       },
     });
   });
@@ -625,13 +785,14 @@ describe('As developer, I can format for update mutation,', () => {
       fileList,
     };
 
-    expect(formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA })).toEqual({
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, {
+        tableName: 'tableSchema',
+        schema: SCHEMA,
+      }),
+    ).toEqual({
       fileList: {
-        reconnect: [
-          {
-            id: fileList[0].id,
-          },
-        ],
+        update: [{ data: fileList[0] }],
       },
     });
   });
@@ -712,6 +873,68 @@ describe('As developer, I can format for update mutation,', () => {
   });
 
   it('Compelex data.', () => {
+    const initialData = {
+      meta: 'initial meta',
+      number: 0,
+      numberList: [],
+      address: {
+        street1: 'Initial Pamelia Quall',
+        street2: 'Initial Lasonya Friedly',
+        zip: 'Initial Timothy Ingleton',
+        city: 'Initial Kenia Urhahn',
+        state: 'Initial Scottie Swailes',
+      },
+      scalar: 'Initial Scalar Value',
+      scalarList: ['Removed Scalar Value', 'Scalar List Value'],
+      relation: {
+        id: 'relation-1',
+        scalar: 'Initial Relation Scalar Value',
+      },
+      fileList: [
+        {
+          id: '1234',
+          fileId: 'file-id',
+          filename: 'Initial Screenshot at авг. 13 15-22-49.png',
+          nonFileField: 'non file field',
+        },
+        {
+          id: 'removed-file-1',
+          fileId: 'file-id',
+          filename: 'Initial Screenshot at авг. 13 15-22-49.png',
+        },
+      ],
+      relationList: [
+        {
+          id: 'relation-list-1',
+          scalar: 'Initial Relation List Scalar Value',
+          scalarList: ['Initial Relation List Scalar List Value'],
+        },
+        {
+          id: 'relation-list-2',
+          scalar: 'Initial Relation List Scalar Value',
+          scalarList: ['Initial Relation List Scalar List Value'],
+          nestedRelation: {
+            id: 'nested-relation-2-1',
+            scalar: 'Initial Nested Relation Scalar Value',
+          },
+          nestedRelationList: [
+            {
+              id: 'nested-relation-2-2',
+              scalar: 'Initial Relation List Nested Relation List Scalar Value',
+              scalarList: ['Initial Relation List Nested Relation List Scalar List Value'],
+            },
+          ],
+        },
+        {
+          id: 'removed-relation-list-1',
+          scalar: 'Initial Relation List Scalar Value',
+          scalarList: ['Initial Relation List Scalar List Value'],
+        },
+      ],
+      _description: 'Description',
+      __typename: 'Address',
+    };
+
     const data = {
       meta: 'meta',
       number: 1,
@@ -726,6 +949,7 @@ describe('As developer, I can format for update mutation,', () => {
       scalar: 'Scalar Value',
       scalarList: ['Scalar List Value'],
       relation: {
+        id: 'relation-1',
         scalar: 'Relation Scalar Value',
       },
       fileList: [
@@ -744,13 +968,51 @@ describe('As developer, I can format for update mutation,', () => {
       ],
       relationList: [
         {
+          id: 'connect-relation-list-1',
+        },
+        {
+          id: 'relation-list-1',
+          scalar: 'Update Relation List Scalar Value',
+          scalarList: ['Update Relation List Scalar List Value'],
+          nestedRelation: {
+            scalar: 'New Nested Relation Scalar Value',
+          },
+          nestedRelationList: [
+            {
+              scalar: 'Relation List Nested Relation List Scalar Value',
+              scalarList: ['Relation List Nested Relation List Scalar List Value'],
+            },
+          ],
+        },
+        {
+          id: 'relation-list-2',
+          scalar: 'Update Relation List Scalar Value',
+          scalarList: ['Update Relation List Scalar List Value'],
+          nestedRelation: {
+            id: 'nested-relation-2-1',
+            scalar: 'Updated Nested Relation Scalar Value',
+          },
+          nestedRelationList: [
+            {
+              id: 'nested-relation-2-2',
+              scalar: 'Relation List Nested Relation List Scalar Value',
+              scalarList: ['Relation List Nested Relation List Scalar List Value'],
+            },
+          ],
+        },
+        {
           scalar: 'Relation List Scalar Value',
           scalarList: ['Relation List Scalar List Value'],
           nestedRelation: '5b32159b66a450c047285628',
           nestedRelationList: [
             {
+              id: 'nested-relation-id',
               scalar: 'Relation List Nested Relation List Scalar Value',
               scalarList: ['Relation List Nested Relation List Scalar List Value'],
+            },
+            {
+              scalar: 'New Relation List Nested Relation List Scalar Value',
+              scalarList: ['New Relation List Nested Relation List Scalar List Value'],
             },
           ],
         },
@@ -760,7 +1022,18 @@ describe('As developer, I can format for update mutation,', () => {
     };
 
     expect(
-      formatDataForMutation(MUTATION_TYPE.UPDATE, data, { tableName: 'tableSchema', schema: SCHEMA }),
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, {
+        tableName: 'tableSchema',
+        schema: SCHEMA,
+        initialData,
+      }),
+    ).toMatchSnapshot();
+
+    expect(
+      formatDataForMutation(MUTATION_TYPE.UPDATE, data, {
+        tableName: 'tableSchema',
+        schema: SCHEMA,
+      }),
     ).toMatchSnapshot();
   });
 


### PR DESCRIPTION
**BREAKING CHANGES**
- `formatDataAfterQuery` doesn't remove `id`
- `formatDataForMutation` uses `update` and `disconnect` instead of `reconnect` for UPDATE 
- `formatDataForMutation` now can accept `initialData` and `disconnect` relations based on it
- `formatDataForMutation` without `initialData` only updates/creates/connects new relations but doesn't remove old relations (reconnect/disconnect)
- `formatDataForMutation` now propagates its options so it changed behaviour in nested data (e.g. now `ignoreNonTableFields` is used in nested calls of `formatDataForMutation`)
- `formatDataForMutation` returns `null` when relation is empty (https://github.com/8base/sdk/compare/master...lesha1201:update_relation?expand=1#diff-729c1486a758bf666dde7945a54fb67aR74)
- Other breaking changes can be seen in tests (https://github.com/8base/sdk/compare/master...lesha1201:update_relation?expand=1#diff-729c1486a758bf666dde7945a54fb67a)
