### PR TITLE
feat(utils): replace graphql-prettier with build-in formatter from prettier

### DIFF
--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@8base/error-codes": "^1.0.22",
     "@8base/schema-name-generator": "^0.1.23",
-    "graphql-prettier": "^1.0.6",
     "prettier": "^2.2.1",
     "ramda": "^0.27.1",
     "reselect": "^4.0.0"

--- a/packages/core/utils/src/formatters/gqlPrettify.ts
+++ b/packages/core/utils/src/formatters/gqlPrettify.ts
@@ -1,0 +1,9 @@
+import prettier from 'prettier';
+import parserGraphql from 'prettier/parser-graphql';
+
+export const gqlPrettify = (gqlString: string): string => {
+  return prettier.format(gqlString, {
+    parser: 'graphql',
+    plugins: [parserGraphql],
+  });
+};

--- a/packages/core/utils/src/formatters/index.ts
+++ b/packages/core/utils/src/formatters/index.ts
@@ -1,3 +1,4 @@
 export { formatDataForMutation } from './formatDataForMutation';
 export { formatDataAfterQuery } from './formatDataAfterQuery';
 export { formatOptimisticResponse } from './formatOptimisticResponse';
+export { gqlPrettify } from './gqlPrettify';

--- a/packages/core/utils/src/queryGenerators/queryGenerators.ts
+++ b/packages/core/utils/src/queryGenerators/queryGenerators.ts
@@ -1,9 +1,9 @@
 import * as R from 'ramda';
 import { SchemaNameGenerator } from '@8base/schema-name-generator';
 import { tablesListSelectors } from '../selectors';
-import gqlPrettier from 'graphql-prettier';
 import * as tableSelectors from '../selectors/tableSelectors';
 import { TableSchema, QueryGeneratorConfig } from '../types';
+import { gqlPrettify } from '../formatters';
 import { SDKError, PACKAGES, ERROR_CODES } from '../errors';
 import { createQueryString } from './createQueryString';
 
@@ -44,7 +44,7 @@ export const createTableFilterGraphqlTag = (
   const appName = tablesListSelectors.getTableApplicationName(tablesList, tableId);
   const { withResultData = true, ...restConfig } = config;
 
-  return gqlPrettier(`
+  return gqlPrettify(`
   query ${upperFirst(table.name)}TableContent(
     $filter: ${SchemaNameGenerator.getFilterInputTypeName(table.name, appName)}
     $orderBy: [${SchemaNameGenerator.getOrderByInputTypeName(table.name, appName)}]
@@ -94,7 +94,7 @@ export const createTableRowCreateTag = (
   const { withResultData = true, ...restConfig } = config;
 
   if (hasCreatableFields) {
-    return gqlPrettier(`
+    return gqlPrettify(`
   mutation ${upperFirst(table.name)}Create($data: ${SchemaNameGenerator.getCreateInputName(table.name, appName)}!) {
     ${wrapInAppName(appName)(`
     ${SchemaNameGenerator.getCreateItemFieldName(table.name)}(data: $data) {
@@ -105,7 +105,7 @@ export const createTableRowCreateTag = (
     }`);
   }
 
-  return gqlPrettier(`
+  return gqlPrettify(`
   mutation ${upperFirst(table.name)}Create {
   ${wrapInAppName(appName)(`
     ${SchemaNameGenerator.getCreateItemFieldName(table.name)} {
@@ -123,7 +123,7 @@ export const createTableRowCreateManyTag = (tablesList: TableSchema[], tableId: 
   const hasCreatableFields = R.pipe(R.propOr([], 'fields'), R.any(R.pathEq(['dataFeatures', 'create'], true)))(table);
 
   if (hasCreatableFields) {
-    return gqlPrettier(`
+    return gqlPrettify(`
   mutation ${upperFirst(table.name)}CreateMany($data: [${SchemaNameGenerator.getCreateManyInputName(
       table.name,
       appName,
@@ -153,9 +153,9 @@ export const createTableRowUpdateTag = (
   const appName = tablesListSelectors.getTableApplicationName(tablesList, tableId);
   const { withResultData = true, ...restConfig } = config;
 
-  return gqlPrettier(`
+  return gqlPrettify(`
     mutation ${upperFirst(table.name)}Update(
-      $data: ${SchemaNameGenerator.getUpdateInputName(table.name, appName)}!, 
+      $data: ${SchemaNameGenerator.getUpdateInputName(table.name, appName)}!,
       $filter: ${SchemaNameGenerator.getKeyFilterInputTypeName(table.name, appName)}
     ) {
     ${wrapInAppName(appName)(`
@@ -176,7 +176,7 @@ export const createTableRowQueryTag = (
   const appName = tablesListSelectors.getTableApplicationName(tablesList, tableId);
   const { withResultData = true, ...restConfig } = config;
 
-  return gqlPrettier(`
+  return gqlPrettify(`
     query ${upperFirst(table.name)}Entity($id: ID!) {
     ${wrapInAppName(appName)(`
       ${SchemaNameGenerator.getTableItemFieldName(table.name)}(id: $id) {
@@ -191,7 +191,7 @@ export const createTableRowDeleteTag = (tablesList: TableSchema[], tableId: stri
   const table = getTable(tablesList, tableId);
   const appName = tablesListSelectors.getTableApplicationName(tablesList, tableId);
 
-  return gqlPrettier(`
+  return gqlPrettify(`
     mutation ${upperFirst(table.name)}Delete($filter: ${SchemaNameGenerator.getKeyFilterInputTypeName(
     table.name,
     appName,

--- a/packages/core/utils/types/graphql-prettier.d.ts
+++ b/packages/core/utils/types/graphql-prettier.d.ts
@@ -1,5 +1,0 @@
-declare module 'graphql-prettier' {
-  const graphqlPrettier: (str: string) => string;
-
-  export default graphqlPrettier;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,13 +5083,6 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-prettier@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/graphql-prettier/-/graphql-prettier-1.0.6.tgz#ec7f0372876950ed41508559cd34e66128f2be4a"
-  integrity sha512-Rq2eRQgT7obypnYb+tE27Ira7BYW+YFMdgZT6azrYgVCldNrULHuYOhWZlvjxBKTAU+t/aj8zneiRBuYnj/SNA==
-  dependencies:
-    graphql "^14.1.1"
-
 graphql-request@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.4.0.tgz#3a400cd5511eb3c064b1873afb059196bbea9c2b"
@@ -5108,13 +5101,6 @@ graphql@*, graphql@^15.5.0:
   version "15.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
   integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
-
-graphql@^14.1.1:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
-  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
-  dependencies:
-    iterall "^1.2.2"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -5956,7 +5942,7 @@ isutf8@^2.1.0:
   resolved "https://registry.yarnpkg.com/isutf8/-/isutf8-2.1.0.tgz#b6d08a02d4ce43bf3b4be39b9b60231b88dfeb2b"
   integrity sha512-rEMU6f82evtJNtYMrtVODUbf+C654mos4l+9noOueesUMipSWK6x3tpt8DiXhcZh/ZOBWYzJ9h9cNAlcQQnMiQ==
 
-iterall@^1.2.1, iterall@^1.2.2:
+iterall@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==


### PR DESCRIPTION
Because `graphql-prettier` package uses a very old version of the `graphql` package dependency, the entire `@8base/utils` package cannot be used in modern environments (for example Creact React App v5) - this will cause errors due to the fact that the older package is used for compatibility, although the project may use the new one.

This problem is also described here: https://github.com/8base/sdk/issues/378

This PR removes this formatter. and replaces it with a built-in formatter from prettier.