### PR TITLE
fix: auth client should not throw error Invalid token specified on method getAuthorizedData

### DIFF
--- a/packages/core/web-auth0-auth-client/src/WebAuth0AuthClient.ts
+++ b/packages/core/web-auth0-auth-client/src/WebAuth0AuthClient.ts
@@ -194,18 +194,21 @@ class WebAuth0AuthClient implements IAuthClient {
         }
 
         const idToken = (getIdToken(authResult) as string) || '';
-        const jwtResult: IAuth0IdTokenData = jwtDecode(idToken) || {};
 
-        resolve({
-          idToken,
-          firstName: jwtResult.given_name,
-          lastName: jwtResult.family_name,
-          picture: jwtResult.picture,
-          email: getEmail(authResult),
-          idTokenPayload: getIdTokenPayload(authResult),
-          isEmailVerified: isEmailVerified(authResult),
-          state: getState(authResult),
-        });
+        if (idToken) {
+          const jwtResult: IAuth0IdTokenData = jwtDecode(idToken) || {};
+
+          resolve({
+            idToken,
+            firstName: jwtResult.given_name,
+            lastName: jwtResult.family_name,
+            picture: jwtResult.picture,
+            email: getEmail(authResult),
+            idTokenPayload: getIdTokenPayload(authResult),
+            isEmailVerified: isEmailVerified(authResult),
+            state: getState(authResult),
+          });
+        }
       });
     });
   }


### PR DESCRIPTION
add validation if token exist

https://github.com/8base/sdk/issues/351
